### PR TITLE
Prevent infinite loop in mission water-search

### DIFF
--- a/commands/mission.js
+++ b/commands/mission.js
@@ -64,7 +64,7 @@ module.exports = {
         else if (missionDuration === 'medium') { minNM = 20; maxNM = 100; }
         else if (missionDuration === 'long') { minNM = 80; maxNM = 300; }
 
-        while (!foundWater) {
+        while (!foundWater && attempt < maxAttempts) {
           const bearing = Math.random() * 360;
           const distance = Math.max(minNM + Math.random() * (maxNM - minNM), 0.5);
           const radians = bearing * (Math.PI / 180);


### PR DESCRIPTION
### Motivation
- Ensure mission point selection loop does not retry indefinitely when no water point is found, preventing API overuse and hanging command execution.

### Description
- Enforce the existing `maxAttempts` guard by changing the loop condition in `commands/mission.js` to `while (!foundWater && attempt < maxAttempts)`.

### Testing
- Verified syntax with `node --check commands/mission.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10406eee84832f9949c35cc2ff57a4)